### PR TITLE
Add support for zoom

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -2,7 +2,7 @@ import defaults from 'lodash/object/defaults';
 import shallowEqual from './shallowEqual';
 import EnterLeaveCounter from './EnterLeaveCounter';
 import { isFirefox } from './BrowserDetector';
-import { getNodeClientOffset, getEventClientOffset, getDragPreviewOffset } from './OffsetUtils';
+import { getNodeClientOffset, getEventClientOffset, getDragPreviewOffset, setZoom } from './OffsetUtils';
 import { createNativeDragSource, matchNativeItemType } from './NativeDragSources';
 import * as NativeTypes from './NativeTypes';
 
@@ -113,7 +113,28 @@ export default class HTML5Backend {
     };
   }
 
-  connectDropTarget(targetId, node) {
+  adjustForDropTargetZoom(node, zoom) {
+    if (zoom) {
+      setZoom(zoom);
+    } else if (node.style && node.style.zoom) {
+      const cssZoom = node.style.zoom.replace(/^\s+|\s+$/g, '');
+      if (cssZoom.length > 0) {
+        if (cssZoom === 'normal') {
+          setZoom(1);
+        } else {
+          let zoomValue = parseFloat(cssZoom);
+          if (isNaN(cssZoom)) {
+            zoomValue /= 100.0;
+          }
+          setZoom(zoomValue);
+        }
+      }
+    }
+  }
+
+  connectDropTarget(targetId, node, zoom) {
+    this.adjustForDropTargetZoom(node, zoom);
+
     const handleDragEnter = (e) => this.handleDragEnter(e, targetId);
     const handleDragOver = (e) => this.handleDragOver(e, targetId);
     const handleDrop = (e) => this.handleDrop(e, targetId);

--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -133,7 +133,9 @@ export default class HTML5Backend {
   }
 
   connectDropTarget(targetId, node, zoom) {
-    this.adjustForDropTargetZoom(node, zoom);
+    if(navigator.userAgent.toLowerCase().indexOf('firefox') == -1) {
+      this.adjustForDropTargetZoom(node, zoom);
+    }
 
     const handleDragEnter = (e) => this.handleDragEnter(e, targetId);
     const handleDragOver = (e) => this.handleDragOver(e, targetId);

--- a/src/OffsetUtils.js
+++ b/src/OffsetUtils.js
@@ -2,6 +2,11 @@ import { isSafari, isFirefox } from './BrowserDetector';
 import MonotonicInterpolant from './MonotonicInterpolant';
 
 const ELEMENT_NODE = 1;
+let zoom = 1.0;
+
+export function setZoom(value) {
+  zoom = value;
+}
 
 export function getNodeClientOffset(node) {
   const el = node.nodeType === ELEMENT_NODE ?
@@ -18,8 +23,8 @@ export function getNodeClientOffset(node) {
 
 export function getEventClientOffset(e) {
   return {
-    x: e.clientX,
-    y: e.clientY
+    x: e.clientX / zoom,
+    y: e.clientY / zoom
   };
 }
 
@@ -34,8 +39,8 @@ export function getDragPreviewOffset(sourceNode, dragPreview, clientOffset, anch
 
   const dragPreviewNodeOffsetFromClient = getNodeClientOffset(dragPreviewNode);
   const offsetFromDragPreview = {
-    x: clientOffset.x - dragPreviewNodeOffsetFromClient.x,
-    y: clientOffset.y - dragPreviewNodeOffsetFromClient.y
+    x: (clientOffset.x - dragPreviewNodeOffsetFromClient.x) * zoom,
+    y: (clientOffset.y - dragPreviewNodeOffsetFromClient.y) * zoom
   };
 
   const { offsetWidth: sourceWidth, offsetHeight: sourceHeight } = sourceNode;


### PR DESCRIPTION
Adds support for drop targets with a css zoom attribute and for manually specifying a zoom value. This is useful when the drop target doesn’t have a zoom css attribute but is a child of a DOM element that has one.
