### PR TITLE
Prevent issue in Firefox when dropping an image

### DIFF
--- a/src/NativeDragSources.js
+++ b/src/NativeDragSources.js
@@ -16,7 +16,7 @@ const nativeTypesConfig = {
     exposeProperty: 'files',
     matchesTypes: ['Files'],
     getData: (dataTransfer) =>
-      Array.prototype.slice.call(dataTransfer.files)
+      dataTransfer.files && Array.prototype.slice.call(dataTransfer.files)
   },
   [NativeTypes.URL]: {
     exposeProperty: 'urls',
@@ -76,7 +76,9 @@ export function matchNativeItemType(dataTransfer) {
   const dataTransferTypes = Array.prototype.slice.call(dataTransfer.types || []);
 
   return Object.keys(nativeTypesConfig).filter(nativeItemType => {
-    const { matchesTypes } = nativeTypesConfig[nativeItemType];
-    return matchesTypes.some(t => dataTransferTypes.indexOf(t) > -1);
+    const nativeTypeConfig = nativeTypesConfig[nativeItemType];
+    const matchesTypes = nativeTypeConfig.matchesTypes;
+    return matchesTypes.some(t => dataTransferTypes.indexOf(t) > -1) &&
+      nativeItemType.getData(dataTransfer);
   })[0] || null;
 }


### PR DESCRIPTION
When dropping an image (from another tab) in Firefox, it sends `'Files'` in the `dataTransfer.types` array but `dataTransfer.files` value is `null`.

This change should prevent a type from being recognized as such if there's no value returning from the `getData` function for that type.

Closes #29
