### PR TITLE
Conflict: Check for dropTargetIds in handleTopDrop()

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -486,6 +486,11 @@ export default class HTML5Backend {
     const { dropTargetIds } = this;
     this.dropTargetIds = [];
 
+    // Make sure we have dropTargetIds
+    if (!dropTargetIds || !dropTargetIds.length) {
+      return;
+    }
+
     this.actions.hover(dropTargetIds, {
       clientOffset: getEventClientOffset(e)
     });


### PR DESCRIPTION
This PR is a fix to address issue #32

Check `dropTargetIds` exists and has a length. If so, do something.
