### PR TITLE
Adding anchorOffset as a configuration for the drag preview

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -285,7 +285,7 @@ export default class HTML5Backend {
         const sourceId = this.monitor.getSourceId();
         const sourceNode = this.sourceNodes[sourceId];
         const dragPreview = this.sourcePreviewNodes[sourceId] || sourceNode;
-        const { anchorX, anchorY } = this.getCurrentSourcePreviewNodeOptions();
+        const { anchorX, anchorY, anchorOffsetX, anchorOffsetY } = this.getCurrentSourcePreviewNodeOptions();
         const anchorPoint = { anchorX, anchorY };
         const dragPreviewOffset = getDragPreviewOffset(
           sourceNode,
@@ -293,7 +293,11 @@ export default class HTML5Backend {
           clientOffset,
           anchorPoint
         );
-        dataTransfer.setDragImage(dragPreview, dragPreviewOffset.x, dragPreviewOffset.y);
+
+        dataTransfer.setDragImage(dragPreview,
+          anchorOffsetX === undefined ? dragPreviewOffset.x : anchorOffsetX,
+          anchorOffsetY === undefined ? dragPreviewOffset.y : anchorOffsetY);
+        //this is the inlye
       }
 
       try {


### PR DESCRIPTION
When the dragPreview differs in width or height from the dragSource, the calculation for the offset will give invalid values.
![image](https://cloud.githubusercontent.com/assets/1027202/17329993/f5c8dc6c-58bc-11e6-948e-072d1a7d7510.png)

In the above image we can see the original in the red box, after starting the drag operation (green box) we resize the boxes to make it easier to the user. Without this PR the dragPreview would show to the far left of the mouse cursor.
