### PR TITLE
Add touch support via custom simulated drag events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
-    "lodash": "^4.2.0"
+    "lodash": "^4.2.0",
+    "touch-dnd-custom-events": "^1.3.0"
   },
   "peerDependencies": {
     "react-dnd": "^2.0.0"

--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -1,4 +1,5 @@
 import defaults from 'lodash/defaults';
+import setupTouchDNDCustomEvents from 'touch-dnd-custom-events';
 import shallowEqual from './shallowEqual';
 import EnterLeaveCounter from './EnterLeaveCounter';
 import { isFirefox } from './BrowserDetector';
@@ -44,6 +45,7 @@ export default class HTML5Backend {
     }
     this.constructor.isSetUp = true;
     this.addEventListeners(window);
+    this.addCustomEventListeners(window);
   }
 
   teardown() {
@@ -53,7 +55,41 @@ export default class HTML5Backend {
 
     this.constructor.isSetUp = false;
     this.removeEventListeners(window);
+    this.removeCustomEventListeners(window);
     this.clearCurrentDragSourceNode();
+  }
+
+  addCustomEventListeners(target) {
+    target.addEventListener(
+      'touchdragstart', this.handleTopDragStart
+    );
+    target.addEventListener(
+      'touchdragstart', this.handleTopDragStartCapture, true
+    );
+    target.addEventListener(
+      'touchdragend', this.handleTopDragEndCapture, true
+    );
+    target.addEventListener(
+      'touchdragenter', this.handleTopDragEnter
+    );
+    target.addEventListener(
+      'touchdragenter', this.handleTopDragEnterCapture, true
+    );
+    target.addEventListener(
+      'touchdragleave', this.handleTopDragLeaveCapture, true
+    );
+    target.addEventListener(
+      'touchdragover', this.handleTopDragOver
+    );
+    target.addEventListener(
+      'touchdragover', this.handleTopDragOverCapture, true
+    );
+    target.addEventListener(
+      'touchdrop', this.handleTopDrop
+    );
+    target.addEventListener(
+      'touchdrop', this.handleTopDropCapture, true
+    );
   }
 
   addEventListeners(target) {
@@ -67,6 +103,39 @@ export default class HTML5Backend {
     target.addEventListener('dragover', this.handleTopDragOverCapture, true);
     target.addEventListener('drop', this.handleTopDrop);
     target.addEventListener('drop', this.handleTopDropCapture, true);
+  }
+
+  removeCustomEventListeners(target) {
+    target.removeEventListener(
+      'touchdragstart', this.handleTopDragStart
+    );
+    target.removeEventListener(
+      'touchdragstart', this.handleTopDragStartCapture, true
+    );
+    target.removeEventListener(
+      'touchdragend', this.handleTopDragEndCapture, true
+    );
+    target.removeEventListener(
+      'touchdragenter', this.handleTopDragEnter
+    );
+    target.removeEventListener(
+      'touchdragenter', this.handleTopDragEnterCapture, true
+    );
+    target.removeEventListener(
+      'touchdragleave', this.handleTopDragLeaveCapture, true
+    );
+    target.removeEventListener(
+      'touchdragover', this.handleTopDragOver
+    );
+    target.removeEventListener(
+      'touchdragover', this.handleTopDragOverCapture, true
+    );
+    target.removeEventListener(
+      'touchdrop', this.handleTopDrop
+    );
+    target.removeEventListener(
+      'touchdrop', this.handleTopDropCapture, true
+    );
   }
 
   removeEventListeners(target) {
@@ -93,6 +162,8 @@ export default class HTML5Backend {
   }
 
   connectDragSource(sourceId, node, options) {
+    setupTouchDNDCustomEvents();
+
     this.sourceNodes[sourceId] = node;
     this.sourceNodeOptions[sourceId] = options;
 
@@ -102,6 +173,7 @@ export default class HTML5Backend {
     node.setAttribute('draggable', true);
     node.addEventListener('dragstart', handleDragStart);
     node.addEventListener('selectstart', handleSelectStart);
+    node.addEventListener('touchdragstart', handleDragStart);
 
     return () => {
       delete this.sourceNodes[sourceId];
@@ -109,6 +181,7 @@ export default class HTML5Backend {
 
       node.removeEventListener('dragstart', handleDragStart);
       node.removeEventListener('selectstart', handleSelectStart);
+      node.removeEventListener('touchdragstart', handleDragStart);
       node.setAttribute('draggable', false);
     };
   }
@@ -122,10 +195,18 @@ export default class HTML5Backend {
     node.addEventListener('dragover', handleDragOver);
     node.addEventListener('drop', handleDrop);
 
+    node.addEventListener('touchdragenter', handleDragEnter);
+    node.addEventListener('touchdragover', handleDragOver);
+    node.addEventListener('touchdrop', handleDrop);
+
     return () => {
       node.removeEventListener('dragenter', handleDragEnter);
       node.removeEventListener('dragover', handleDragOver);
       node.removeEventListener('drop', handleDrop);
+
+      node.removeEventListener('touchdragenter', handleDragEnter);
+      node.removeEventListener('touchdragover', handleDragOver);
+      node.removeEventListener('touchdrop', handleDrop);
     };
   }
 


### PR DESCRIPTION
This pull request adds drag and drop support for touch devices to _react-dnd-html5-backend_, removing the need to switch between different backends (i.e. no need to use _react-dnd-touch-backend_ anymore). It aims to address some of the wishes raised in the issue [16](https://github.com/gaearon/react-dnd/issues/16) and pull request [240](https://github.com/gaearon/react-dnd/pull/240) in _react-dnd_

It works by using the library [touch-dnd-custom-events](https://www.npmjs.com/package/touch-dnd-custom-events) to map touch events (_touchstart_, _touchmove_, _touchend_) to custom versions of html5 drag and drop events as follows:

<table style="width: 100%">
  <tr style="">
    <th>touch event</th>
    <th>drag event(s)</th>
  </tr>
  <tr>
    <td>touchstart</td>
    <td>touchdragstart</td>
  </tr>
  <tr>
    <td>touchmove</td>
    <td>
      touchdrag<br/>
      touchdragenter<br/>
      touchdragover<br/>
      touchdragleave<br/>
    </td>
  </tr>
  <tr>
    <td>touchend</td>
    <td>
      touchdrop<br/>
      touchdragend<br/>
    </td>
  </tr>
</table>

The custom drag events generated by _touch-dnd-custom-events_ are crafted to comply with the html spec for [Drag and Drop](https://html.spec.whatwg.org/multipage/interaction.html#dnd). This allows _react-dnd-html5-backend_ (or any other library using _touch-dnd-custom-events_) to treat these custom events as if they were browser generated drag and drop events. (Duck Typing for the win!)